### PR TITLE
Refactor logging and debug statements in export and import modules

### DIFF
--- a/static/js/modules/common.js
+++ b/static/js/modules/common.js
@@ -42,12 +42,6 @@ export class CommonModule {
         // Preserve the full node type (including variations) - getNodeConfig normalizes internally
         const nodeType = shelfNode.data('shelf_node_type') || 'WH_GALAXY';
         const config = getNodeConfig(nodeType);
-        
-        // #region agent log
-        if (nodeType && nodeType.includes('P150')) {
-            fetch('http://localhost:7242/ingest/2a8b0834-f05b-4e6c-a5f2-95d9e5fa046b',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'common.js:44',message:'arrangeTraysAndPorts P150_LB',data:{shelfId:shelfNode.id(),nodeType:nodeType,configFound:!!config,configTrayCount:config?.tray_count,configPortCount:config?.ports_per_tray,trayLayout:config?.tray_layout,numTrays:shelfNode.children('[type="tray"]').length},timestamp:Date.now(),sessionId:'debug-session'})}).catch(()=>{});
-        }
-        // #endregion
 
         if (!config) {
             console.warn(`No config found for node type: ${nodeType} (after normalization)`);

--- a/static/js/modules/ui-display.js
+++ b/static/js/modules/ui-display.js
@@ -1045,16 +1045,6 @@ export class UIDisplayModule {
                 console.log('Clearing existing elements and adding new ones');
                 this.state.cy.elements().remove();
                 this.state.cy.add(data.elements);
-                
-                // #region agent log
-                const shelves = this.state.cy.nodes('[type="shelf"]');
-                shelves.forEach(shelf => {
-                    const nodeType = shelf.data('shelf_node_type');
-                    if (nodeType && nodeType.includes('P150')) {
-                        fetch('http://localhost:7242/ingest/2a8b0834-f05b-4e6c-a5f2-95d9e5fa046b',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'ui-display.js:1048',message:'initVisualization imported shelf P150_LB',data:{shelfId:shelf.id(),shelfNodeType:nodeType,numTrays:shelf.children('[type="tray"]').length,numPorts:shelf.children('[type="port"]').length},timestamp:Date.now(),sessionId:'debug-session'})}).catch(()=>{});
-                    }
-                });
-                // #endregion
 
                 // Apply drag restrictions
                 this.commonModule.applyDragRestrictions();


### PR DESCRIPTION
This commit removes redundant debug logging and simplifies the code in the `export_descriptors.py` and `import_cabling.py` files. Key changes include:

- Eliminated debug print statements related to edge processing and connection extraction in `export_descriptors.py`, streamlining the connection handling logic.
- Removed unnecessary logging related to node type normalization and hostname tracking in `import_cabling.py`, enhancing code clarity and maintainability.
- Cleaned up the `common.js` and `ui-display.js` files by removing agent log fetch calls, reducing console noise during visualization.

These changes aim to improve code readability and maintainability while ensuring that essential functionality remains intact.