### PR TITLE
Fixes For Deployment Flows/Container Flow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.github
+node_modules
+**/__pycache__
+**/*.pyc
+.pytest_cache
+*.log
+.env
+.venv
+venv
+defined_topologies
+README*.md
+nginx/oauth2-setup.md

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,6 +43,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          target: release
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,59 +1,77 @@
-# TT-CableGen Dockerfile
+# TT-CableGen Dockerfile (slim, multi-stage)
+#
+# builder: compiles scaleout tools using the heavy tt-metal image (discarded).
+# release: minimal ubuntu carrying only the runtime closure the app uses.
+# dev:     release + npm for in-container Jest/pytest checks.
 
 #############################################################
-
-# Use the published tt-metal base image instead of rebuilding
-# This includes basic build tools (cmake, ninja, g++, mpi-ulfm)
-FROM ghcr.io/tenstorrent/tt-metal/tt-metalium-ubuntu-22.04-release-amd64:latest AS base
-
+# Builder
 #############################################################
+FROM ghcr.io/tenstorrent/tt-metal/tt-metalium-ubuntu-22.04-release-amd64:latest AS builder
 
-FROM base AS release
-
-# Set up TT_METAL_HOME
-# (PYTHON_ENV_DIR is already set in the base image)
 ENV TT_METAL_HOME=/tt-metal
-ENV APP_HOME=/app
 ARG TT_METAL_HASH=fbb677b7197ee126f76c9ebbfc2ba28b6d980442
 
-COPY requirements.txt requirements.txt
-RUN /bin/bash -c "python3 -m ensurepip --upgrade && python3 -m pip install --no-cache-dir -r requirements.txt; apt update && apt install -y protobuf-compiler npm"
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends protobuf-compiler git \
+    && rm -rf /var/lib/apt/lists/*
 
-# Clone tt-metal for scaleout dependencies
-RUN /bin/bash -c "git clone --filter=blob:none --tags \
-    https://github.com/tenstorrent/tt-metal.git ${TT_METAL_HOME} \
-    && cd ${TT_METAL_HOME}"
-
+RUN git clone --filter=blob:none --tags https://github.com/tenstorrent/tt-metal.git ${TT_METAL_HOME}
 WORKDIR ${TT_METAL_HOME}
-
-# Fetch and checkout the exact commit (shallow fetch for that commit only)
-RUN /bin/bash -c "git fetch origin ${TT_METAL_HASH} && git checkout ${TT_METAL_HASH} && git submodule update --init --recursive"
+RUN git fetch origin ${TT_METAL_HASH} \
+    && git checkout ${TT_METAL_HASH} \
+    && git submodule update --init --recursive
 
 COPY build_scaleout.sh ${TT_METAL_HOME}/build_scaleout.sh
-RUN chmod +x ${TT_METAL_HOME}/build_scaleout.sh
+RUN chmod +x build_scaleout.sh && ./build_scaleout.sh --build-dir build
 
-RUN /bin/bash -c "${TT_METAL_HOME}/build_scaleout.sh --build-dir build"
+#############################################################
+# Release (minimal runtime)
+#############################################################
+FROM ubuntu:22.04 AS release
+
+ENV TT_METAL_HOME=/tt-metal
+ENV APP_HOME=/app
+ENV PYTHON_ENV_DIR=/opt/venv
+ENV PATH=/opt/venv/bin:${PATH}
+
+# Runtime shared-lib deps of run_cabling_generator (see ldd closure) + python.
+# glibc/libstdc++/libgcc/krb5 sub-libs come transitively or from the base.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python3 python3-venv \
+        libhwloc15 libtirpc3 libudev1 libnsl2 libatomic1 zlib1g libgssapi-krb5-2 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m venv ${PYTHON_ENV_DIR}
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Built artifacts. Paths are preserved verbatim: the binary's RUNPATH points at
+# /tt-metal/build/tt_stl and /tt-metal/build/tt_metal/third_party/umd/device, and
+# server.py/import_cabling.py/export_descriptors.py resolve everything under
+# $TT_METAL_HOME/build/tools/scaleout.
+COPY --from=builder /tt-metal/build/tools/scaleout/run_cabling_generator /tt-metal/build/tools/scaleout/run_cabling_generator
+COPY --from=builder /tt-metal/build/tt_stl/libtt_stl.so /tt-metal/build/tt_stl/libtt_stl.so
+COPY --from=builder /tt-metal/build/tt_metal/third_party/umd/device/libdevice.so /tt-metal/build/tt_metal/third_party/umd/device/libdevice.so
+COPY --from=builder /tt-metal/build/tools/scaleout/protobuf/cluster_config_pb2.py /tt-metal/build/tools/scaleout/protobuf/cluster_config_pb2.py
+COPY --from=builder /tt-metal/build/tools/scaleout/protobuf/node_config_pb2.py /tt-metal/build/tools/scaleout/protobuf/node_config_pb2.py
+COPY --from=builder /tt-metal/build/tools/scaleout/protobuf/deployment_pb2.py /tt-metal/build/tools/scaleout/protobuf/deployment_pb2.py
 
 WORKDIR ${APP_HOME}
-# Copy Flask web server files
-# Bust docker build cache
-ARG CACHEBUST=1
-RUN echo "Busting docker build cache at $(date): $CACHEBUST"
-
 COPY templates/ ${APP_HOME}/templates/
 COPY server.py ${APP_HOME}/server.py
 COPY import_cabling.py ${APP_HOME}/import_cabling.py
 COPY export_descriptors.py ${APP_HOME}/export_descriptors.py
 COPY static/ ${APP_HOME}/static/
 
-# Expose ports for tt-cablegen server
-# Port 5000: Web server
 EXPOSE 5000
-
-
-# Set the Flask server as the entrypoint
-# This allows passing command line arguments directly to docker run
 ENTRYPOINT ["/bin/bash", "-c", "python3 ${APP_HOME}/server.py -p 5000"]
 
 #############################################################
-
+# Dev / test (adds npm for in-container checks)
+#############################################################
+FROM release AS dev
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends npm \
+    && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,10 @@ ENV PATH=/opt/venv/bin:${PATH}
 
 # Runtime shared-lib deps of run_cabling_generator (see ldd closure) + python.
 # glibc/libstdc++/libgcc/krb5 sub-libs come transitively or from the base.
+# curl is for the compose healthcheck (both local and prod).
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        python3 python3-venv \
+        python3 python3-venv curl \
         libhwloc15 libtirpc3 libudev1 libnsl2 libatomic1 zlib1g libgssapi-krb5-2 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -4,6 +4,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      target: dev
     platform: linux/amd64
     pull_policy: always
     container_name: cablegen-app-local

--- a/static/js/modules/export.js
+++ b/static/js/modules/export.js
@@ -198,6 +198,10 @@ export class ExportModule {
      * @returns {boolean} True if any host indices were changed during the pass.
      */
     runHostIndexSanityPass() {
+        // Preserve hierarchy-assigned host_ids; don't re-derive order from racking.
+        if (this.state.data.initialMode === 'hierarchy') {
+            return false;
+        }
         if (!this.commonModule?.recalculateHostIndices || typeof this.commonModule.recalculateHostIndices !== 'function') {
             return false;
         }


### PR DESCRIPTION
This pull request introduces a multi-stage, slim Docker build process and related improvements to the development workflow, dependency management, and build caching. The main changes focus on separating build, release, and development environments for the Docker image, optimizing what is included in the final image, and improving the local development experience. There are also minor application logic improvements.

**Docker build and workflow improvements:**

* Refactored the `Dockerfile` to use a multi-stage build with distinct `builder`, `release`, and `dev` targets, significantly reducing the final image size and separating build-time and runtime dependencies. The `release` stage now only includes the minimal runtime closure required for the application, while the `dev` stage adds `npm` for in-container testing.
* Added a `.dockerignore` file to exclude unnecessary files and directories (e.g., `.git`, `node_modules`, Python caches, docs) from the Docker build context, further reducing image size and build time.
* Updated the GitHub Actions workflow (`docker-publish.yml`) to build and push the `release` target from the multi-stage Dockerfile, ensuring only the minimal runtime image is published.
* Changed the local development Docker Compose configuration to build the `dev` target, enabling local testing with all necessary dev dependencies.

**Application logic:**

* Updated `runHostIndexSanityPass` in `static/js/modules/export.js` to preserve host IDs assigned via hierarchy mode, preventing unnecessary recalculation of host indices when in hierarchical configuration mode.