### PR TITLE
Fix Large Topology Upload/Download Issues

### DIFF
--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -57,6 +57,9 @@ acme_issuer acme_server {
         # Handle large headers from OAuth2 providers (especially Entra ID)
         large_client_header_buffers 4 32k;
 
+        # Allow large topology payloads (deployment descriptor + cytoscape data)
+        client_max_body_size 100m;
+
         # Security headers
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header X-Frame-Options DENY always;
@@ -74,8 +77,8 @@ acme_issuer acme_server {
 
         # Timeout settings
         proxy_connect_timeout 30s;
-        proxy_send_timeout 30s;
-        proxy_read_timeout 30s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
 
         # Buffer settings for better performance
         proxy_buffering on;

--- a/nginx/nginx.local.conf
+++ b/nginx/nginx.local.conf
@@ -9,6 +9,9 @@ server {
     listen 80;
     server_name localhost;
 
+    # Allow large topology payloads (deployment descriptor + cytoscape data)
+    client_max_body_size 100m;
+
     # Health check endpoint
     location /health {
         access_log off;
@@ -28,8 +31,8 @@ server {
 
         # Timeout settings
         proxy_connect_timeout 30s;
-        proxy_send_timeout 30s;
-        proxy_read_timeout 30s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
 
         # Buffer settings for better performance
         proxy_buffering on;

--- a/static/js/visualizer.js
+++ b/static/js/visualizer.js
@@ -1830,7 +1830,17 @@ async function applyDeploymentDescriptor(file) {
 
     try {
         const response = await fetch('/apply_deployment_descriptor', { method: 'POST', body: formData });
-        const result = await response.json();
+        let result;
+        try {
+            result = await response.json();
+        } catch (parseErr) {
+            // Server returned a non-JSON body (e.g. an nginx 413/504 error page).
+            // Surface a useful message instead of a raw "Unexpected token" SyntaxError.
+            if (response.status === 413) {
+                throw new Error('Topology is too large for the server to accept. Please contact an administrator to raise the upload size limit.');
+            }
+            throw new Error(`Server returned an unexpected response (HTTP ${response.status}). The topology may be too large or the request timed out.`);
+        }
         if (response.ok && result.success) {
             // Keep in-memory snapshot in sync with full graph (important when payload was built from cy)
             if (result.data?.elements) {
@@ -1914,7 +1924,17 @@ async function applyDeploymentDescriptorFromModal() {
 
     try {
         const response = await fetch('/apply_deployment_descriptor', { method: 'POST', body: formData });
-        const result = await response.json();
+        let result;
+        try {
+            result = await response.json();
+        } catch (parseErr) {
+            // Server returned a non-JSON body (e.g. an nginx 413/504 error page).
+            // Surface a useful message instead of a raw "Unexpected token" SyntaxError.
+            if (response.status === 413) {
+                throw new Error('Topology is too large for the server to accept. Please contact an administrator to raise the upload size limit.');
+            }
+            throw new Error(`Server returned an unexpected response (HTTP ${response.status}). The topology may be too large or the request timed out.`);
+        }
         if (response.ok && result.success) {
             if (result.data?.elements) {
                 state.data.currentData = result.data;


### PR DESCRIPTION
Apply deployment descriptor from hierarchy mode POSTs the deployment file plus the full cytoscape data, which exceeds nginx's default 1MB body limit for large topologies. nginx then returns a 413 HTML page that the frontend tries to JSON.parse, producing a confusing JSON parsing error.

- nginx: set client_max_body_size 100m (dev + prod configs)
- nginx: raise proxy send/read timeouts 30s -> 60s
- frontend: handle non-JSON responses with a clear message instead of a raw "Unexpected token" SyntaxError