### PR TITLE
Add Display Options sidebar section with port-number and rack-order t…

### DIFF
--- a/static/js/modules/common.js
+++ b/static/js/modules/common.js
@@ -1240,23 +1240,55 @@ export class CommonModule {
             }
         });
 
-        // Port hover handlers - show labels on hover, hide on mouseout; raise port above connections
-        // Port labels are always "P<port # on tray>", not identifiers
+        // Port hover handlers - show labels on hover; on mouseout revert to whatever the
+        // "Show all port numbers" toggle dictates. Raise port above connections while hovered.
+        // Port labels are always "P<port # on tray>", not identifiers.
         this.state.cy.on('mouseover', 'node.port', (evt) => {
             const port = evt.target;
-            const portNum = port.data('port');
-            const labelValue = (portNum != null && portNum !== undefined) ? `P${portNum}` : (port.data('label') || '');
-            port.style('label', labelValue);
+            port.style('label', this._portLabelText(port));
             port.addClass('port-hover');
         });
 
         this.state.cy.on('mouseout', 'node.port', (evt) => {
             const port = evt.target;
-            port.style('label', '');
+            // Keep the label if the global toggle is on; otherwise hide it again.
+            if (this._showAllPortNumbers()) {
+                port.style('label', this._portLabelText(port));
+            } else {
+                port.style('label', '');
+            }
             port.removeClass('port-hover');
         });
 
+        // Re-apply the persistent "show all port numbers" preference for this (re)render.
+        this.applyPortNumberVisibility();
+
         console.log('[addCytoscapeEventHandlers] Event handlers registered successfully');
+    }
+
+    /** Whether the global "Show all port numbers" display toggle is enabled. */
+    _showAllPortNumbers() {
+        return document.getElementById('showAllPortNumbers')?.checked ?? false;
+    }
+
+    /** The label text for a port node, always "P<port#>". */
+    _portLabelText(port) {
+        const portNum = port.data('port');
+        return (portNum != null) ? `P${portNum}` : (port.data('label') || '');
+    }
+
+    /**
+     * Apply the global "show all port numbers" preference to every port. When enabled, each
+     * port persistently shows its "P<port#>" label; when disabled, labels are hidden except
+     * on hover. Uses per-element style bypasses (like the hover handlers) and reads the
+     * checkbox directly so it survives graph re-renders. Called on toggle and after each render.
+     */
+    applyPortNumberVisibility() {
+        if (!this.state.cy) return;
+        const show = this._showAllPortNumbers();
+        this.state.cy.nodes('.port').forEach((port) => {
+            port.style('label', show ? this._portLabelText(port) : '');
+        });
     }
 
     /**

--- a/static/js/modules/location.js
+++ b/static/js/modules/location.js
@@ -425,11 +425,13 @@ export class LocationModule {
             });
         });
 
-        // Sort racks within each aisle by rack number (descending - higher rack numbers to the left)
+        // Sort racks within each aisle by rack number (descending by default - higher rack
+        // numbers to the left; reversed when the "Reverse rack order" display option is on).
+        const rackOrderDir = this.isReverseRackOrder() ? -1 : 1;
         Object.keys(rackHierarchy).forEach(hall => {
             Object.keys(rackHierarchy[hall]).forEach(aisle => {
                 rackHierarchy[hall][aisle].sort((a, b) => {
-                    return b.rack_num - a.rack_num; // Descending order - rack 2 to the left of rack 1
+                    return rackOrderDir * (b.rack_num - a.rack_num);
                 });
             });
         });
@@ -780,6 +782,25 @@ export class LocationModule {
      * Switch to location/physical mode - save hierarchy state then rebuild visualization from current graph.
      * Use this when the user toggles from hierarchy to location mode.
      */
+    /**
+     * Whether the "Reverse rack order" display option is enabled. Read directly from the
+     * checkbox (consistent with the other sidebar display filters) so the rack sort
+     * comparators pick it up on every (re)layout.
+     */
+    isReverseRackOrder() {
+        return document.getElementById('reverseRackOrder')?.checked ?? false;
+    }
+
+    /**
+     * Re-run the location layout so a change to the "Reverse rack order" option takes effect
+     * immediately. Only meaningful in location mode, where racks are laid out horizontally.
+     */
+    applyReverseRackOrder() {
+        if (this.state.mode === 'location') {
+            this.rebuildLocationViewFromCurrentGraph();
+        }
+    }
+
     switchMode() {
         // Stop any running hierarchy layout so the visualizer doesn't stay frozen
         if (typeof window.hierarchyModule?.stopLayout === 'function') {
@@ -1007,11 +1028,13 @@ export class LocationModule {
                         });
                     }
 
-                    // Sort racks in descending order (higher rack numbers to the left)
+                    // Sort racks in descending order by default (higher rack numbers to the
+                    // left); reversed when the "Reverse rack order" display option is on.
+                    const rackOrderDir = this.isReverseRackOrder() ? -1 : 1;
                     const sortedRackKeys = Object.keys(locationHierarchy[hall][aisle]).sort((a, b) => {
                         const rackA = parseInt(a) || 0;
                         const rackB = parseInt(b) || 0;
-                        return rackB - rackA; // Descending order - rack 2 to the left of rack 1
+                        return rackOrderDir * (rackB - rackA);
                     });
                     // Precompute inside width per rack (from shelf node types) so adjacent racks don't overlap
                     const createRackInsideWidths = sortedRackKeys.map(rackKey => {

--- a/static/js/visualizer.js
+++ b/static/js/visualizer.js
@@ -881,6 +881,10 @@ function setupEventListeners() {
     attachEventListener('applyLayoutBtn', 'click', () => uiDisplayModule.applyPhysicalLayoutModalAction());
     attachEventListener('applyUploadBtn', 'click', () => applyDeploymentDescriptorFromModal().catch(err => console.error('Error applying deployment descriptor:', err)));
 
+    // Display options
+    attachEventListener('showAllPortNumbers', 'change', () => commonModule.applyPortNumberVisibility());
+    attachEventListener('reverseRackOrder', 'change', () => locationModule.applyReverseRackOrder());
+
     // Collapsible headers
     document.querySelectorAll('.collapsible-header[data-section]').forEach(header => {
         const sectionId = header.getAttribute('data-section');

--- a/templates/index.html
+++ b/templates/index.html
@@ -1116,6 +1116,35 @@
                     </div>
                 </div>
 
+                <div class="collapsible-header" data-section="displayOptions">
+                    <h3 style="margin: 0; color: #333;">Display Options </h3>
+                    <span class="collapsible-arrow collapsed" id="displayOptions-arrow">▶</span>
+                </div>
+                <div class="collapsible-content collapsed" id="displayOptions">
+                    <div class="range-filter-section">
+                        <div style="display: flex; flex-direction: column; gap: 8px;">
+                            <label style="display: flex; align-items: center; cursor: pointer; color: #333333;">
+                                <input type="checkbox" id="showAllPortNumbers"
+                                    style="margin-right: 8px; transform: scale(1.1);">
+                                <span style="font-size: 14px;">Show all port numbers</span>
+                            </label>
+                            <div style="font-size: 11px; color: #666; margin-left: 24px; margin-top: -2px;">
+                                Display port numbers on every port (otherwise shown on hover)
+                            </div>
+                            <div class="location-mode-only" style="margin-top: 4px;">
+                                <label style="display: flex; align-items: center; cursor: pointer; color: #333333;">
+                                    <input type="checkbox" id="reverseRackOrder"
+                                        style="margin-right: 8px; transform: scale(1.1);">
+                                    <span style="font-size: 14px;">Reverse rack order</span>
+                                </label>
+                                <div style="font-size: 11px; color: #666; margin-left: 24px; margin-top: -2px;">
+                                    Reverse the left-to-right ordering of racks within each aisle
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
                 <div class="collapsible-header" data-section="connectionRangeFilter">
                     <h3 style="margin: 0; color: #333;">Connection Options </h3>
                     <span class="collapsible-arrow collapsed" id="connectionRangeFilter-arrow">▶</span>


### PR DESCRIPTION
Display Option Toggles

Adds a new collapsible "Display Options" section to the sidebar with two visualization toggles addressing user feedback:

- Show all port numbers: persistently label every port with "P<n>" instead of only on hover. Implemented via per-element style bypass (shared with the hover handlers) and re-applied after each render so it survives graph re-renders and mode switches.
- Reverse rack order: invert the left-to-right ordering of racks within each aisle in location mode, for DCs that number racks front/back. Both rack-sort comparators honor the flag and the location view is rebuilt immediately on toggle. Shown only in location mode.